### PR TITLE
plot-file can now plot column 1 against remaining columns in data file.

### DIFF
--- a/vgplot.lisp
+++ b/vgplot.lisp
@@ -221,16 +221,6 @@ nil comment line \(or empty line)"
         t ; there was data before EOL or comment but no other separator
         nil))) ; comment-only line
 
-(defun get-cmd-string (data-file &optional x-in-file)
-  (if x-in-file
-      (format nil "plot \"~A\" using 1:($2) with lines" data-file)
-      (format nil "plot \"~A\" using ($1) with lines" data-file)))
-
-(defun get-next-cmd-string (data-file i &optional x-in-file)
-  (if x-in-file
-      (format nil ", \"~A\" using 1:($~A) with lines" data-file i)
-      (format nil ", \"~A\" using ($~A) with lines" data-file i)))
-
 (defun count-data-columns (s &optional (separator))
   "Count data columns in strings like \"1 2 3 # comment\", seperators
 could be a variable number of spaces, tabs or the optional separator"
@@ -579,13 +569,14 @@ Observe, gnuplot doesn't allow interactive mouse commands in multiplot mode.
       (read-n-print-no-hang (plot-stream act-plot))
       (force-output (plot-stream act-plot))
       (read-n-print-no-hang (plot-stream act-plot))))
-  (defun plot-file (data-file &optional x-in-file)
+  (defun plot-file (data-file &key (x-col))
     "Plot data-file directly, datafile must hold columns separated by spaces, tabs or commas
-\(other separators may work), use with-lines style"
+\(other separators may work), use with-lines style.
+                :x-col     (optional) column to use as x values.
+                           plot to index if not provided"
     (let ((c-num)
           (separator)
-          (cmd-string (get-cmd-string data-file x-in-file))
-          (second-y (if x-in-file 3 1)))
+          (cmd-string ""))
       (with-open-file (in data-file :direction :input)
         (setf separator (do ((c (get-separator (read-line in))
                                 (get-separator (read-line in))))
@@ -594,11 +585,24 @@ Observe, gnuplot doesn't allow interactive mouse commands in multiplot mode.
         (setf c-num (do ((num (count-data-columns (read-line in) separator)
                               (count-data-columns (read-line in) separator)))
                         ((> num 0) num))))
-      (loop for i from second-y to c-num do
-         (setf cmd-string (concatenate 'string cmd-string
-                                       (get-next-cmd-string data-file i x-in-file))))
+
+      (flet ((add-cmd (data-file x-col y-col current-cmd)
+	       (unless (eql x-col y-col)
+		 (let ((plot-or-comma (if (string= current-cmd "") "plot" ",")))
+		   (if x-col
+		       (format nil "~A \"~A\" using ~A:($~A) with lines"
+			       plot-or-comma data-file x-col y-col)
+		       (format nil "~A \"~A\" using ($~A) with lines"
+			       plot-or-comma data-file y-col))))))
+	(loop
+	   for i from 1 to c-num
+	   do
+             (setf cmd-string
+		   (concatenate 'string cmd-string
+				(add-cmd data-file x-col i cmd-string)))))
+
       (unless act-plot
-        (setf act-plot (make-plot)))
+	(setf act-plot (make-plot)))
       (format (plot-stream act-plot) "set grid~%")
       (when (characterp separator)
         (format (plot-stream act-plot) "set datafile separator \"~A\"~%" separator))
@@ -606,7 +610,7 @@ Observe, gnuplot doesn't allow interactive mouse commands in multiplot mode.
       (when (characterp separator)
         (format (plot-stream act-plot) "set datafile separator~%")) ; reset separator
       (force-output (plot-stream act-plot)))
-    (read-n-print-no-hang (plot-stream act-plot)))
+  (read-n-print-no-hang (plot-stream act-plot)))
 )
 
 ;; figure is an alias to new-plot (because it's used that way in octave/matlab)


### PR DESCRIPTION
plot-file takes &optional argument which should be T if the first
column in the data-file contains x-values, and omitted (or NIL)
otherwise.

The new DEFUNs get-cmd-string and get-next-cmd-string return the
appropriate gnuplot command strings depending on the value of
x-in-file argument.